### PR TITLE
Make addHeader be usable from regular GHC

### DIFF
--- a/src/GHCJS/HPlay/View.hs
+++ b/src/GHCJS/HPlay/View.hs
@@ -1505,10 +1505,14 @@ runWidget' action e  = Widget $ Transient $ do
 
 -- | add a header in the <header> tag
 addHeader :: Perch -> IO ()
+#ifdef ghcjs_HOST_OS
 addHeader format= do
     head <- getHead
     build format head
     return ()
+#else
+addHeader _ = return ()
+#endif
 
 
 -- | run the widget as the body of the HTML. It adds the rendering to the body of the document.


### PR DESCRIPTION
When using `addHeader` outside GHCJS, one gets a runtime error because it is undefined. With this, it just does nothing.